### PR TITLE
Instructions for OPENAI_API_KEY as env var and in IDEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
  
 > ✨ Navigate at [cookbook.openai.com](https://cookbook.openai.com)
 
-Example code and guides for accomplishing common tasks with the [OpenAI API](https://platform.openai.com/docs/introduction). To run these examples, you'll need an OpenAI account and associated API key ([create a free account here](https://beta.openai.com/signup)).
+Example code and guides for accomplishing common tasks with the [OpenAI API](https://platform.openai.com/docs/introduction). To run these examples, you'll need an OpenAI account and associated API key ([create a free account here](https://beta.openai.com/signup)). Set an environment variable called `OPENAI_API_KEY` with your API key. Alternatively, in most IDEs such as Visual Studio Code, you can create an `.env` file at the root of your repo containing `OPENAI_API_KEY=<your API key>`, which will be picked up by the notebooks.
 
 Most code examples are written in Python, though the concepts can be applied in any language.
 


### PR DESCRIPTION
I've seen a bunch of folks (including myself) accidentally paste their API keys into PRs. I think this is because many are unaware that you can just add an .env file with your key. Adding that as a pointer in README.md - while I'm not sure if this is the place it should go, I think a pointer like this would be helpful.

## Summary

Add instructions on best practices to handle API keys.

## Motivation

I've seen a bunch of folks (including myself) accidentally paste their API keys into PRs. I think this is because many are unaware that you can just add an .env file with your key. 

Would love your feedback if the README.md file is the right place for this - we could also add a HOWTO.md like the already existing CONTRIBUTING.md. Let me know any feedback / questions / comments / critique you have!